### PR TITLE
SYS-69: replace TokuDB with RocksDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,96 @@
+# heplify-server (fork)
+
 ![image](https://user-images.githubusercontent.com/1423657/38167610-1bccc596-3538-11e8-944c-8bd9ee0433b2.png)
 
 **heplify-server** is a stand-alone **HOMER** capture server developed in Go, optimized for speed and simplicity. Distributed as a single binary ready to capture TLS and UDP **HEP**, Protobuf encapsulated packets from [heplify](https://github.com/sipcapture/heplify) or any other [HEP](https://github.com/sipcapture/hep) enabled agent, indexing to database and rotating using H5 or H7 table format. **heplify-server** provides precise SIP and RTCP metrics with the help of Prometheus and Grafana. It gives you the possibility to get a global view on your network and individual SIP trunk monitoring.
 
 *TLDR; minimal, stand-alone HOMER capture server without Kamailio or OpenSIPS dependency. It's not as customizeable as Kamailio or OpenSIPS with their configuration language, the focus is simplicity!*
 
-------
+--
 
-### Installation
+## Installation
+
 You have 3 options to get **heplify-server** up and running:
 
 * Download a [release](https://github.com/sipcapture/heplify-server/releases)
 * Docker [compose](https://github.com/sipcapture/heplify-server/tree/master/docker/hom5-hep-prom-graf)
-* Compile from sources:  
-  
+* Compile from sources:
+
   Install luajit dev libary
-  
+
   `apt-get install libluajit-5.1-dev`
-  
-  or 
-  
-  `yum install luajit-devel` 
-  
+
+  or
+
+  `yum install luajit-devel`
+
+  or for macOS
+
+  ```sh
+  # Assuming brew installs to /usr/local/
+  brew install lua@5.1 luajit
+  ln -s /usr/local/lib/pkgconfig/luajit.pc /usr/local/lib/pkgconfig/luajit-5.1.pc
+  export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
+  ```
+
   [install](https://golang.org/doc/install) Go 1.11+
 
   `go build cmd/heplify-server/heplify-server.go`
-  
-  
 
-### Requirements
+## Requirements
+
 These depend on which features you want to use and on whether you use homer5 or homer7 schema. For homer5, you need MySQL >= 5.7 or MariaDB >= 10. For homer7 you need PostgreSQL >= 10.
 
-### Configuration
-**heplify-server** can be configured using command-line flags, environment variables, or a local [configuration file](https://github.com/sipcapture/heplify-server/blob/master/example/) or via web form by setting ConfigHTTPAddr  
+## Configuration
+
+**heplify-server** can be configured using command-line flags, environment variables, or a local [configuration file](https://github.com/sipcapture/heplify-server/blob/master/example/) or via web form by setting ConfigHTTPAddr
 
 ![image](https://user-images.githubusercontent.com/20154956/54483281-ef3f5700-4850-11e9-8da1-9b8bed6186e3.png)
 
-To set up a systemd service, use the sample [service file](https://github.com/sipcapture/heplify-server/blob/master/example/) 
+To set up a systemd service, use the sample [service file](https://github.com/sipcapture/heplify-server/blob/master/example/)
 and follow the instructions found at the top of the file.
 
 Since version 0.92 it is possible to hot reload PromTargetIP and PromTargetName when you change them inside the configuration file.
-```
+
+```sh
 killall -HUP heplify-server
 ```
 
 ### Running
-##### Stand-Alone
-```
+
+#### Stand-Alone
+
+```sh
 ./heplify-server -h
 ```
-##### Docker
+
+#### Docker
+
 A sample Docker [compose](https://github.com/sipcapture/heplify-server/tree/master/docker/hom5-hep-prom-graf) file is available providing heplify-server, Homer 5 UI, Prometheus, Alertmanager and Grafana in seconds!
-```
+
+```sh
 cd heplify-server/docker/hom5-hep-prom-graf/
 docker-compose up -d
 ```
 
 ### Support
+
 * Testers, Reporters and Contributors [welcome](https://github.com/sipcapture/heplify-server/issues)
 
 ### Screenshots
+
 ![sip_metrics](https://user-images.githubusercontent.com/20154956/39880524-57838c04-547e-11e8-8dec-262184192742.png)
+
 ![xrtp](https://user-images.githubusercontent.com/20154956/39880861-4b1a2b34-547f-11e8-8d38-69fa88713aa9.png)
+
 ![loki](https://user-images.githubusercontent.com/20154956/70985139-ee777200-20bb-11ea-867b-200cd7e1b6b8.png)
-----
-#### Made by Humans
-This Open-Source project is made possible by actual Humans without corporate sponsors, angels or patreons.<br>
+
+--
+
+### Made by Humans
+
+This Open-Source project is made possible by actual Humans without corporate sponsors, angels or patreons.
+
 If you use this software in production, please consider supporting its development with contributions or [donations](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=donation%40sipcapture%2eorg&lc=US&item_name=SIPCAPTURE&no_note=0&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHostedGuest)
 
-[![Donate](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=donation%40sipcapture%2eorg&lc=US&item_name=SIPCAPTURE&no_note=0&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHostedGuest) 
+[![Donate](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=donation%40sipcapture%2eorg&lc=US&item_name=SIPCAPTURE&no_note=0&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHostedGuest)

--- a/rotator/mariafiles.go
+++ b/rotator/mariafiles.go
@@ -299,7 +299,7 @@ var tbldatasipmaria = []string{
 		KEY source_ip (source_ip),
 		KEY destination_ip (destination_ip),
 		KEY user_agent (user_agent)
-	  ) ENGINE=TokuDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
+	  ) ENGINE=RocksDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
 	  PARTITION BY RANGE ( UNIX_TIMESTAMP(date) ) (
 		  PARTITION {{date}}_{{minTime}} VALUES LESS THAN ( UNIX_TIMESTAMP('{{endTime}}') )
 	  );`,
@@ -362,7 +362,7 @@ var tbldatasipmaria = []string{
 		KEY source_ip (source_ip),
 		KEY destination_ip (destination_ip),
 		KEY user_agent (user_agent)
-	  ) ENGINE=TokuDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
+	  ) ENGINE=RocksDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
 	  PARTITION BY RANGE ( UNIX_TIMESTAMP(date) ) (
 		  PARTITION {{date}}_{{minTime}} VALUES LESS THAN ( UNIX_TIMESTAMP('{{endTime}}') )
 	  );`,
@@ -425,7 +425,7 @@ var tbldatasipmaria = []string{
 		KEY source_ip (source_ip),
 		KEY destination_ip (destination_ip),
 		KEY user_agent (user_agent)
-	  ) ENGINE=TokuDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
+	  ) ENGINE=RocksDB DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
 	  PARTITION BY RANGE ( UNIX_TIMESTAMP(date) ) (
 		  PARTITION {{date}}_{{minTime}} VALUES LESS THAN ( UNIX_TIMESTAMP('{{endTime}}') )
 	  );`,


### PR DESCRIPTION
From ticket SYS-69:

_This also involves building a different version of Heplify Server. https://github.com/VoIPGRID/heplify-server Our own build of Heplify Server is mostly identical except that is creates TokuDB tables instead of InnoDB tables. For Bullseye, it should create MYROCKS tables instead._