### PR TITLE
Use Debian Bullseye, not "ubuntu-latest"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
       - 'v*'
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: debian-bullseye
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
- TokuDB --> RocksDB for database engine (file `rotator/mariafiles.go`)
- Using Ubuntu will use Jammy for binary build, causing glibc version issues.