### PR TITLE
Replace sipcapture with VoIPGRID in Go files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ heplify-server
 fuzz-workdir
 sipparser-fuzz.zip
 heplify-server.toml
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,8 +27,20 @@ nfpms:
     vendor: VoIPGRID
     homepage: https://www.voipgrid.nl
     maintainer: VoIPGRID <info@voipgrid.nl>
-    description: Homer heplify ingester service
+    description: |-
+      Homer heplify ingester service
+      HEP Capture Server & Switch in Go - with RocksDB
+    contents:
+      - src: ./LICENSE
+        dst: /usr/share/doc/heplify-server/copyright
+        file_info:
+          mode: 0644
     formats:
       - deb
+    deb:
+      lintian_overrides:
+        - changelog-file-missing-in-native-package
+        - hardening-no-pie
+        - no-manual-page
 changelog:
   disable: true

--- a/.lintian-overrides
+++ b/.lintian-overrides
@@ -1,0 +1,3 @@
+heplify-server: changelog-file-missing-in-native-package
+heplify-server: hardening-no-pie
+heplify-server: no-manual-page

--- a/cmd/heplify-server/heplify-server.go
+++ b/cmd/heplify-server/heplify-server.go
@@ -15,8 +15,8 @@ import (
 	"github.com/negbie/logp"
 	"github.com/negbie/multiconfig"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/sipcapture/heplify-server/config"
-	input "github.com/sipcapture/heplify-server/server"
+	"github.com/VoIPGRID/heplify-server/config"
+	input "github.com/VoIPGRID/heplify-server/server"
 )
 
 type server interface {

--- a/database/database.go
+++ b/database/database.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/decoder"
 	"github.com/valyala/fasttemplate"
 )
 

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -6,8 +6,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/decoder"
 	"github.com/valyala/bytebufferpool"
 )
 

--- a/database/header.go
+++ b/database/header.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/buger/jsonparser"
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/decoder"
 	"github.com/valyala/bytebufferpool"
 	"github.com/valyala/fasttemplate"
 )

--- a/database/mock.go
+++ b/database/mock.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/decoder"
 	"github.com/valyala/bytebufferpool"
 	"golang.org/x/sync/syncmap"
 )

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -6,8 +6,8 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/decoder"
 )
 
 var (

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -6,8 +6,8 @@ import (
 
 	_ "github.com/lib/pq"
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/decoder"
 	"github.com/valyala/bytebufferpool"
 )
 

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -15,8 +15,8 @@ import (
 	"github.com/VictoriaMetrics/fastcache"
 	xxhash "github.com/cespare/xxhash/v2"
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/sipparser"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/sipparser"
 )
 
 // The first 4 bytes are the string "HEP3". The next 2 bytes are the length of the

--- a/decoder/exprengine.go
+++ b/decoder/exprengine.go
@@ -7,7 +7,7 @@ import (
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/vm"
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/sipparser"
+	"github.com/VoIPGRID/heplify-server/sipparser"
 )
 
 // ExprEngine struct

--- a/decoder/luaengine.go
+++ b/decoder/luaengine.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/negbie/logp"
 	"github.com/sipcapture/golua/lua"
-	"github.com/sipcapture/heplify-server/decoder/luar"
+	"github.com/VoIPGRID/heplify-server/decoder/luar"
 )
 
 // LuaEngine

--- a/decoder/scriptengine.go
+++ b/decoder/scriptengine.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/sipcapture/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/config"
 )
 
 // ScriptEngine interface

--- a/decoder/sip.go
+++ b/decoder/sip.go
@@ -3,8 +3,8 @@ package decoder
 import (
 	"errors"
 
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/sipparser"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/sipparser"
 )
 
 func (h *HEP) parseSIP() error {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sipcapture/heplify-server
+module github.com/VoIPGRID/heplify-server
 
 go 1.23
 

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/decoder"
 )
 
 type Metric struct {

--- a/metric/prometheus.go
+++ b/metric/prometheus.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/VictoriaMetrics/fastcache"
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/decoder"
 )
 
 const (

--- a/metric/prometheus_test.go
+++ b/metric/prometheus_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/decoder"
 )
 
 var pmCh = make(chan *decoder.HEP, 20000)

--- a/metric/reload.go
+++ b/metric/reload.go
@@ -6,7 +6,7 @@ import (
 	"unicode"
 
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/config"
 )
 
 func cutSpace(str string) string {

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,33 @@
+---
+# Run as
+# [1] goreleaser build --clean --snapshot
+# [2] nfpm -f nfpm.yaml pkg --packager deb --target ./dist/
+
+name: "heplify-server"
+arch: "amd64"
+platform: "linux"
+version: "1.56.4"
+section: "misc"
+priority: "optional"
+provides:
+  - heplify-server
+depends:
+  - libc6
+  - libluajit-5.1-2
+  - libluajit-5.1-common
+maintainer: "VoIPGRID <info@voipgrid.nl>"
+description: |
+  Homer heplify ingester service
+  HEP Capture Server & Switch in Go - with RocksDB
+vendor: "VoIPGRID"
+homepage: "https://www.voipgrid.nl"
+contents:
+  - src: ./dist/heplify-server_linux_amd64_v1/heplify-server
+    dst: /usr/bin/heplify-server
+  - src: ./LICENSE
+    dst: /usr/share/doc/heplify-server/copyright
+    file_info:
+      mode: 0644
+  - src: .lintian-overrides
+    dst: ./usr/share/lintian/overrides/heplify-server
+    packager: deb

--- a/remotelog/elasticsearch.go
+++ b/remotelog/elasticsearch.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/negbie/logp"
 	"github.com/olivere/elastic"
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/decoder"
 )
 
 type Elasticsearch struct {

--- a/remotelog/loki.go
+++ b/remotelog/loki.go
@@ -16,9 +16,9 @@ import (
 	"github.com/golang/snappy"
 	"github.com/negbie/logp"
 	"github.com/prometheus/common/model"
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/decoder"
-	"github.com/sipcapture/heplify-server/remotelog/logproto"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/remotelog/logproto"
 )
 
 const (

--- a/remotelog/remotelog.go
+++ b/remotelog/remotelog.go
@@ -2,7 +2,7 @@ package remotelog
 
 import (
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/decoder"
 )
 
 type Remotelog struct {

--- a/rotator/rotator.go
+++ b/rotator/rotator.go
@@ -12,8 +12,8 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/negbie/logp"
 	"github.com/robfig/cron/v3"
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/database"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/database"
 )
 
 const (

--- a/server/server.go
+++ b/server/server.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/database"
-	"github.com/sipcapture/heplify-server/decoder"
-	"github.com/sipcapture/heplify-server/metric"
-	"github.com/sipcapture/heplify-server/remotelog"
-	"github.com/sipcapture/heplify-server/rotator"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/database"
+	"github.com/VoIPGRID/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/metric"
+	"github.com/VoIPGRID/heplify-server/remotelog"
+	"github.com/VoIPGRID/heplify-server/rotator"
 )
 
 type HEPInput struct {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/negbie/logp"
-	"github.com/sipcapture/heplify-server/config"
-	"github.com/sipcapture/heplify-server/decoder"
+	"github.com/VoIPGRID/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/decoder"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/server/tls.go
+++ b/server/tls.go
@@ -8,7 +8,7 @@ import (
 	"time"
 	"path/filepath"
 
-	"github.com/sipcapture/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/config"
 	"github.com/negbie/cert"
 	"github.com/negbie/logp"
 )

--- a/sipparser/authorization.go
+++ b/sipparser/authorization.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/sipcapture/heplify-server/sipparser/internal"
+	"github.com/VoIPGRID/heplify-server/sipparser/internal"
 )
 
 type Authorization struct {

--- a/sipparser/from.go
+++ b/sipparser/from.go
@@ -9,7 +9,7 @@ package sipparser
 import (
 	"fmt"
 
-	"github.com/sipcapture/heplify-server/sipparser/internal"
+	"github.com/VoIPGRID/heplify-server/sipparser/internal"
 )
 
 type parseFromStateFn func(f *From) parseFromStateFn

--- a/sipparser/parser.go
+++ b/sipparser/parser.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sipcapture/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/config"
 )
 
 const (

--- a/sipparser/parser_test.go
+++ b/sipparser/parser_test.go
@@ -11,7 +11,7 @@ import (
 	//"fmt"
 	"testing"
 
-	"github.com/sipcapture/heplify-server/config"
+	"github.com/VoIPGRID/heplify-server/config"
 )
 
 var testInviteMsg = "INVITE sip:15554440000@X.X.X.X:5060;user=phone SIP/2.0\r\nVia: SIP/2.0/UDP X.X.X.X:5060;branch=z9hG4bK34133a599ll241207INV21d7d0684e84a2d2\r\nMax-Forwards: 35\r\nContact: <sip:X.X.X.X:5060>\r\nTo: <sip:15554440000@X.X.X.X;user=phone;noa=national>\r\nFrom: \"Unavailable\"<sip:X.X.X.X;user=phone;noa=national>;tag=21d7d068-co2149-FOOI003\r\nCall-ID: 1393184968_47390262@domain.com\r\nCSeq: 214901 INVITE\r\nAuthorization: Digest username=\"foobaruser124\", realm=\"FOOBAR\", algorithm=MD5, uri=\"sip:foo.bar.com\", nonce=\"4f6d7a1d\", response=\"6a79a5c75572b0f6a18963ae04e971cf\", opaque=\"\"\r\nAllow: INVITE,ACK,CANCEL,BYE,REFER,OPTIONS,NOTIFY,SUBSCRIBE,PRACK,INFO\r\nContent-Type: application/sdp\r\nDate: Thu, 29 Sep 2011 16:54:42 GMT\r\nUser-Agent: FAKE-UA-DATA\r\nP-Asserted-Identity: \"Unavailable\"<sip:Restricted@X.X.X.X:5060>\r\nContent-Length: 322\r\n\r\nv=0\r\no=- 567791720 567791720 IN IP4 X.X.X.X\r\ns=FAKE-DATA\r\nc=IN IP4 X.X.X.X\r\nt=0 0\r\nm=audio 17354 RTP/AVP 0 8 86 18 96\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:86 G726-32/8000\r\na=rtpmap:18 G729/8000\r\na=rtpmap:96 telephone-event/8000\r\na=maxptime:20\r\na=fmtp:18 annexb=yes\r\na=fmtp:96 0-15\r\na=sendrecv\r\n"


### PR DESCRIPTION
- Replace sipcapture with VoIPGRID in Go files
- A slightly more valid Debian package build with nfpm and goreleaser